### PR TITLE
Provide Support for Fennel

### DIFF
--- a/lovebird.lua
+++ b/lovebird.lua
@@ -9,9 +9,10 @@
 
 local socket = require "socket"
 
-local lovebird = { _version = "0.4.3" }
+local lovebird = { _version = "0.4.4" }
 
 lovebird.loadstring = loadstring or load
+lovebird.loadstringAlt = lovebird.loadString
 lovebird.inited = false
 lovebird.host = "*"
 lovebird.buffer = ""
@@ -40,7 +41,7 @@ if req.parsedbody.input then
   if str:find("^=") then
     str = "print(" .. str:sub(2) .. ")"
   end
-  xpcall(function() assert(lovebird.loadstring(str, "input"))() end,
+  xpcall(function() assert(lovebird.loadstringAlt(str, "input"))() end,
          lovebird.onerror)
 end
 ?>
@@ -426,7 +427,14 @@ lovebird.pages["env.json"] = [[
 }
 ]]
 
-
+if (fennel) then
+   lovebird.loadstringAlt =  function (str, other)
+      local compiled = fennel["compile-string"](str)
+      local ret = loadstring(compiled)
+      print (fennel.view(ret()))
+      return ret
+   end
+end
 
 function lovebird.init()
   -- Init server


### PR DESCRIPTION
## Changes

Introduced a new function `lovebird.loadstringAlt`. 

By default it points to the same function as `lovebird.loadstring`. If `fennel` is in the global namespace it points to  a new function described below. 

`lovebird.loadstringAlt` is only used for the "index" page. It is always called within an `xpcall`.

## Impact
If `fennel` is not present in the global name space, the functionality of lovebird does not change.

If `fennel` is present, then it can be used directly in the browser console.

I recommend a minor version bump. This does not break backwards compatibility.

## loadstringAlt

If fennel is not nil (i.e., in the global space), opt to use `fennel.compile-string` and `loadstring` in place of raw `loadstring`

If fennel is not nil, always print the result using `fennel.view`.